### PR TITLE
Restructure code to allow integration tests to test correctly

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,9 +3,7 @@ import * as fs from 'fs';
 import * as express from 'express';
 import * as bodyParser from 'body-parser';
 import * as logger from 'morgan';
-import * as config from 'confucious';
 
-import { IDiscordController } from './controllers/discord';
 import { IApiController } from './controllers/api';
 
 export function setupApp(
@@ -27,15 +25,23 @@ export function setupApp(
     });
     express.disable('x-powered-by');
 
-    // https configuration
-    const options = {
-        key: fs.readFileSync('./keys/key.pem'),
-        cert: fs.readFileSync('./keys/cert.pem')
-    };
+    if (fs.existsSync('./keys/key.pem') && fs.existsSync('./keys/cert.pem')) {
+        // https configuration
+        const options = {
+            key: fs.readFileSync('./keys/key.pem'),
+            cert: fs.readFileSync('./keys/cert.pem')
+        };
 
-    if (options.key.length > 0 && options.cert.length > 0) {
-        console.log('listening on port 443');
-        return https.createServer(options, express).listen(443);
+        if (options.key.length > 0 && options.cert.length > 0) {
+            console.log('SSL key and certificate found, creating server...');
+            return https.createServer(options, express);
+        }
+        else {
+            throw new Error('SSL Certificate or Key is empty!');
+        }
     }
-    return undefined;
+    else {
+        throw new Error('SSL Certificate and/or Key do not exist!\n'
+            + 'Place \'key.pem\' & \'cert.pem\' into a \'keys\' directory (./keys/<name>.pem)');
+    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,11 +70,10 @@ async function createServer() {
 
         const server = setupApp(app, apiController);
 
-        // if (server) {
-        console.log('Running HTTPS server');
-        //     return server;
-        // }
-        // else {
+        if (server) {
+            console.log('Running HTTPS server on port 443');
+            server.listen(443);
+        }
         console.log('Running HTTP server');
         return app.listen(app.get('port'), () => {
             logger.info('  App is running at http://localhost:{port} in {env} mode',
@@ -83,7 +82,6 @@ async function createServer() {
 
             logger.info('  Press CTRL-C to stop\n');
         });
-        // }
     } catch (e) {
         logger.fatal('Unable to setup server: {e}', e);
         throw e;


### PR DESCRIPTION
 - Add checks to see if SSL files exist before reading them
 - Move server.listen() out into server.ts to prevent the integration test from failing due to a port conflict